### PR TITLE
Creator footer, privacy note + 24h upload purge, shareable banana score card

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# fixmybanana
+
+Flask app (Python 3.11, gunicorn) live at www.fixmybanana.com. Hosted on Railway, Cloudflare in front for DNS/proxy. Code at github.com/shhirl/fixmybanana.
+
+## ⚠️ Deploy safety — main IS production
+
+Railway auto-deploys every push to `main`. There is no staging. Follow this workflow:
+
+- **Behavior changes (`app.py`, `templates/`, `static/` used by pages): never push directly to main.** Create a short-lived branch, open a PR, and let Shirley merge — merging is the deploy decision and it's hers.
+- **Docs-only changes (README.md, TODO.md, CLAUDE.md, typos): direct to main is fine.**
+- Don't push at all unless asked. Committing locally when asked is fine.
+- If a deploy breaks the site: Railway dashboard → previous deploy → rollback (one click). The `/` healthcheck already blocks boot-failure deploys from replacing the running one, but NOT 200-but-broken bugs (template/JS errors) — that's what the PR checkpoint is for.
+
+## Conventions
+
+- `TODO.md` is the living decisions log — add new decisions there (dated, with Why / How to apply), move finished work to its Done section.
+- Feedback form posts to Formspree (`mqewoaln`) — no backend feedback route; don't add one.
+- Uploads are ephemeral by design: `purge_old_uploads()` deletes files >24h old, backing the homepage privacy note. If storage strategy changes, the privacy note must change with it.
+- Two GitHub accounts in `gh` keyring (`shhirl`, `shirleysbot`); repo-local git config pins author to shhirl. Check `gh auth status` before pushing.
+
+## Verify before declaring done
+
+No test suite yet. Minimum smoke check: with the venv's python, import `app`, `test_client().get('/')` returns 200, and render each template in `templates/` with representative args (see TODO.md Done 2026-07-23 for the exact checks used).

--- a/README.md
+++ b/README.md
@@ -1,17 +1,61 @@
-# fixmybanana
-AI-powered handstand posture analyzer that detects "banana back" when you upload a photo of your handstand, and provides personalized coaching advice.
+# 🍌 fixmybanana
 
-File Structure
+Is your handstand secretly a banana? Upload a photo and find out.
+
+**👉 Try it live: [www.fixmybanana.com](https://www.fixmybanana.com)**
+
+<!-- TODO(shirley): record the demo GIF and save it as static/demo.gif, then delete this comment.
+     Quick recipe: QuickTime or Kap (getkap.co) → record the upload→result flow on the live site
+     → export/convert to GIF (Kap exports GIF directly) → save to static/demo.gif → commit.
+     The image tag below will light up automatically. -->
+<!-- ![Demo: upload a handstand photo, get your banana verdict](static/demo.gif) -->
+
+AI-powered handstand posture analyzer that detects "banana back" (that telltale arched-spine C-shape) from a photo, explains what's off, and hands you a shareable banana score card.
+
+## How it works
+
+1. **Upload** a side-on photo of your handstand
+2. **GPT-4o vision** classifies it as *good form* or *banana back*
+3. **Banana backs** get specific coaching feedback on spinal alignment, hip position, and body line
+4. **Share** your banana score card and challenge your friends
+
+## Stack
+
+- Python 3.11 / Flask, served by gunicorn
+- Deployed on [Railway](https://railway.app) with Cloudflare in front
+- OpenAI vision API for classification + coaching feedback
+- Flask-Limiter rate limiting (5 uploads/day per IP) to bound API costs
+
+## Run locally
+
+```bash
+pip install -r requirements.txt
+export OPENAI_API_KEY=sk-...
+python app.py   # → http://localhost:1010
+```
+
+## Privacy
+
+Uploaded photos are sent to OpenAI for analysis and auto-deleted from the server within 24 hours. Nothing is shared or sold.
+
+## File structure
+
 ```
 fixmybanana/
 ├── app.py                 # Main Flask application
 ├── requirements.txt       # Python dependencies
-├── Procfile              # Railway deployment config
-├── templates/            # HTML templates
-│   ├── base.html
-│   ├── index.html
-│   └── result.html
-├── static/               # Static assets (optional demo images)
-├── uploads/              # User uploaded images (auto-created)
-└── README.md
+├── Procfile               # Railway deployment config
+├── railway.json           # Railway build/deploy settings
+├── templates/             # HTML templates
+│   ├── base.html          # Layout, styles, footer
+│   ├── index.html         # Upload page
+│   ├── result.html        # Verdict + shareable score card
+│   └── 429.html           # Rate-limit page
+├── static/                # Images (demo, background, reactions)
+├── uploads/               # User uploads (auto-created, purged after 24h)
+└── TODO.md                # Living decisions log
 ```
+
+---
+
+Built by [Shirley He](https://www.whirleyworld.com) · [LinkedIn](https://www.linkedin.com/in/shhirl) · [Instagram](https://www.instagram.com/shirleywhirlhe) · [GitHub](https://github.com/shhirl)

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,11 @@ Living doc. Add new items at the top of each section. Move done items to "Done" 
 
 ## Now / next
 
+- [ ] **Record demo GIF for the README.** QuickTime or Kap → record the upload→result flow → export GIF → save as `static/demo.gif` → uncomment the image tag in README.md.
+- [ ] **Pin the repo on GitHub.** Manual step (no API for profile pins): github.com/shhirl → "Customize your pins" on the profile page → check fixmybanana.
+
 - [ ] **Persistent storage for uploaded images + analysis results.**
+  *2026-07-23 note:* uploads now auto-purge after 24h (privacy promise on homepage). If you later pick S3/R2 or a Railway Volume here, either drop the purge or update the homepage privacy note to match.
   Today: images save to local `uploads/` (ephemeral on Railway — wiped on every redeploy). No metadata, no log of who uploaded what.
   Pick one path:
   - **S3 / Cloudflare R2** (cheap, durable, signed URLs for serving back)
@@ -28,6 +32,14 @@ Living doc. Add new items at the top of each section. Move done items to "Done" 
 
 ## Decisions made
 
+- **2026-07-23 — Branch + PR for behavior changes; direct-to-main only for docs.**
+  Why: Railway auto-deploys every push to `main`, so `git push` = "deploy to live site." The healthcheck (`/`) catches boot failures but not 200-but-broken bugs (template/JS breakage). A PR is the deliberate "ready to be live?" checkpoint and keeps main always-deployable.
+  How to apply:
+  - Touching `app.py` or `templates/` → work on a short-lived branch, open a PR, merge = conscious deploy.
+  - README/TODO/typos → direct to main is fine.
+  - Something broke anyway → Railway dashboard → roll back to previous deploy (one click).
+  - Nice-to-haves not yet done: Railway PR preview environments (Settings → Environments), smoke-test CI (`test_app.py` + GitHub Action) + branch protection.
+
 - **2026-04-26 — GitHub auth via `gh` CLI (HTTPS), not SSH host aliases.**
   Two accounts (`shhirl`, `shirleysbot`) both stored in `gh` keyring. `gh auth setup-git` wires git's HTTPS credentials through `gh`, so the *currently active* `gh` account is the one `git push` uses.
   Switch with `gh auth switch -u shhirl` or `gh auth switch -u shirleysbot`.
@@ -41,6 +53,7 @@ Living doc. Add new items at the top of each section. Move done items to "Done" 
 
 ## Done
 
+- **2026-07-23** — Brand + viral-loop pass: (1) footer on every page — "Built by Shirley He" linking to LinkedIn (`/in/shhirl`), Instagram (`@shirleywhirlhe`), GitHub (`shhirl`), and whirleyworld.com; (2) one-line privacy note on homepage, backed by a real `purge_old_uploads()` that deletes uploads older than 24h on each new upload; (3) shareable banana score card on the result page — canvas-rendered 1080×1080 PNG (verdict + user photo + fixmybanana.com), Web Share API with file support on mobile, download + clipboard fallback on desktop; (4) README rewritten with live link, stack, privacy section, and a commented-out demo-GIF slot.
 - **2026-05-12** — Rate-limited `/upload` to 5/day per IP + 50/day globally via `Flask-Limiter`. Belt-and-suspenders with the OpenAI hard cap ($20/day) set in the OpenAI billing dashboard. ProxyFix wraps the WSGI app so Railway's edge proxy doesn't make every request look like one IP. Custom 429 template matches the banana aesthetic. In-memory storage backend (resets on redeploy — fine for now).
 - **2026-04-26** — Swapped feedback handling to Formspree. Removed the `/feedback` Flask route, `FEEDBACK_FILE` constant, datetime import, and `feedback.jsonl` from `.gitignore`. Form now posts directly to `https://formspree.io/f/mqewoaln` with `_next`/`_subject`/`_gotcha` hidden fields. Added `maxlength="5000"` on the textarea so users see the limit instead of having it silently truncated server-side.
 - **2026-04-26** — Added feedback section to homepage (textarea + required email), `/feedback` POST route, thank-you banner on redirect, `.gitignore` for user data. *(Superseded by Formspree swap above — the route is gone, but the section/UX remains.)*

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, request, render_template, jsonify, redirect, url_for, send_from_directory
 import os
 import base64
+import time
 from werkzeug.utils import secure_filename
 from werkzeug.middleware.proxy_fix import ProxyFix
 import requests
@@ -32,6 +33,17 @@ ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif'}
 def allowed_file(filename):
     return '.' in filename and \
            filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+def purge_old_uploads(max_age_hours=24):
+    """Delete uploaded photos older than max_age_hours, backing the privacy promise on the homepage."""
+    cutoff = time.time() - max_age_hours * 3600
+    for name in os.listdir(app.config['UPLOAD_FOLDER']):
+        path = os.path.join(app.config['UPLOAD_FOLDER'], name)
+        try:
+            if os.path.isfile(path) and os.path.getmtime(path) < cutoff:
+                os.remove(path)
+        except OSError:
+            pass
 
 def encode_image_to_base64(image_path):
     """Convert image to base64 string"""
@@ -280,6 +292,7 @@ def upload_file():
         return redirect(request.url)
     
     if file and allowed_file(file.filename):
+        purge_old_uploads()
         filename = secure_filename(file.filename)
         filepath = os.path.join(app.config['UPLOAD_FOLDER'], filename)
         file.save(filepath)

--- a/templates/base.html
+++ b/templates/base.html
@@ -215,6 +215,56 @@
             text-align: center;
             font-weight: 600;
         }
+        .privacy-note {
+            text-align: center;
+            font-size: 13px;
+            color: #6b7280;
+            margin: 14px 0 0;
+        }
+        .share-section {
+            margin: 30px 0;
+            padding: 20px;
+            background: linear-gradient(180deg, #fffef7, #fff8e1);
+            border: 2px solid #ffd700;
+            border-radius: 12px;
+            text-align: center;
+        }
+        .share-title {
+            font-weight: 800;
+            font-size: 18px;
+            color: #1f2330;
+            margin: 0 0 14px;
+        }
+        .share-buttons {
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+        }
+        .share-buttons button {
+            flex: 1 1 200px;
+            width: auto;
+        }
+        .site-footer {
+            margin: 24px auto 8px;
+            padding: 14px 20px;
+            text-align: center;
+            background-color: rgba(255,255,255,0.92);
+            border-radius: 12px;
+            font-size: 14px;
+            color: #6b7280;
+            box-shadow: 0 4px 14px rgba(18,23,35,0.06);
+        }
+        .site-footer p {
+            margin: 0 0 4px;
+        }
+        .site-footer a {
+            color: #5a34e6;
+            text-decoration: none;
+            font-weight: 600;
+        }
+        .site-footer a:hover {
+            text-decoration: underline;
+        }
         .visually-hidden {
             position: absolute;
             width: 1px;
@@ -232,7 +282,17 @@
     <div class="container">
         {% block content %}{% endblock %}
     </div>
-    
+
+    <footer class="site-footer">
+        <p>Built by <a href="https://www.whirleyworld.com" target="_blank" rel="noopener">Shirley He</a></p>
+        <nav>
+            <a href="https://www.linkedin.com/in/shhirl" target="_blank" rel="noopener">LinkedIn</a> ·
+            <a href="https://www.instagram.com/shirleywhirlhe" target="_blank" rel="noopener">Instagram</a> ·
+            <a href="https://github.com/shhirl" target="_blank" rel="noopener">GitHub</a> ·
+            <a href="https://www.whirleyworld.com" target="_blank" rel="noopener">whirleyworld.com</a>
+        </nav>
+    </footer>
+
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             const uploadArea = document.getElementById('uploadArea');

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,6 +38,8 @@
     </div>
 </form>
 
+<p class="privacy-note">🔒 Your photo is sent to OpenAI for analysis and auto-deleted from our server within 24 hours — never shared, never sold.</p>
+
 <div style="margin-top: 40px; padding: 20px; background-color: #e9f7ef; border-radius: 8px;">
     <h3>How It Works</h3>
     <ol>

--- a/templates/result.html
+++ b/templates/result.html
@@ -34,8 +34,18 @@
 <!-- Display the user's uploaded image -->
 <div style="text-align: center; margin: 30px 0;">
     <h3 style="color: #333; margin-bottom: 15px;">📸 Your Handstand Photo</h3>
-    <img src="{{ url_for('uploaded_file', filename=uploaded_image) }}" alt="Your uploaded handstand" style="max-width: 100%; max-height: 400px; height: auto; border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.2); border: 3px solid #ddd;">
+    <img id="resultPhoto" src="{{ url_for('uploaded_file', filename=uploaded_image) }}" alt="Your uploaded handstand" style="max-width: 100%; max-height: 400px; height: auto; border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.2); border: 3px solid #ddd;">
 </div>
+
+{% if form_quality in ['good', 'bad'] %}
+<div class="share-section">
+    <p class="share-title">📣 Share your banana score</p>
+    <div class="share-buttons">
+        <button type="button" id="shareBtn" data-quality="{{ form_quality }}">Share it</button>
+        <button type="button" id="downloadBtn">Download score card</button>
+    </div>
+</div>
+{% endif %}
 
 <!-- Show shocked banana image only for banana back form -->
 {% if form_quality == 'bad' %}
@@ -65,6 +75,110 @@
                 document.body.style.backgroundSize = '256px 256px';
             }
         } catch (e) {}
+    })();
+
+    // Shareable banana score card
+    (function() {
+        var shareBtn = document.getElementById('shareBtn');
+        var downloadBtn = document.getElementById('downloadBtn');
+        if (!shareBtn || !downloadBtn) return;
+
+        var isBanana = shareBtn.dataset.quality === 'bad';
+        var photo = document.getElementById('resultPhoto');
+        var siteUrl = 'https://www.fixmybanana.com';
+        var shareText = isBanana
+            ? 'My handstand is 100% banana 🍌 Get your banana score at ' + siteUrl
+            : 'My handstand is 0% banana ✅ Think you can match it? ' + siteUrl;
+
+        function whenPhotoReady() {
+            return new Promise(function(resolve) {
+                if (!photo) return resolve(null);
+                if (photo.complete && photo.naturalWidth) return resolve(photo);
+                photo.onload = function() { resolve(photo); };
+                photo.onerror = function() { resolve(null); };
+            });
+        }
+
+        function buildCard() {
+            return whenPhotoReady().then(function(img) {
+                var size = 1080;
+                var canvas = document.createElement('canvas');
+                canvas.width = size;
+                canvas.height = size;
+                var ctx = canvas.getContext('2d');
+                var font = '-apple-system, "Segoe UI", Roboto, Arial, sans-serif';
+
+                var grad = ctx.createLinearGradient(0, 0, 0, size);
+                grad.addColorStop(0, '#ffe45c');
+                grad.addColorStop(1, '#ffc300');
+                ctx.fillStyle = grad;
+                ctx.fillRect(0, 0, size, size);
+
+                ctx.textAlign = 'center';
+                ctx.fillStyle = '#1f2330';
+                ctx.font = '800 68px ' + font;
+                ctx.fillText(isBanana ? '🍌 BANANA ALERT! 🍌' : '✅ SOLID FORM ✅', size / 2, 120);
+                ctx.font = '700 44px ' + font;
+                ctx.fillText('Banana score: ' + (isBanana ? '100%' : '0%') + ' banana', size / 2, 190);
+
+                var frame = { x: 165, y: 240, w: 750, h: 620 };
+                ctx.fillStyle = '#ffffff';
+                if (ctx.roundRect) {
+                    ctx.beginPath();
+                    ctx.roundRect(frame.x, frame.y, frame.w, frame.h, 24);
+                    ctx.fill();
+                } else {
+                    ctx.fillRect(frame.x, frame.y, frame.w, frame.h);
+                }
+                if (img) {
+                    var pad = 20;
+                    var scale = Math.min((frame.w - pad * 2) / img.naturalWidth, (frame.h - pad * 2) / img.naturalHeight);
+                    var w = img.naturalWidth * scale;
+                    var h = img.naturalHeight * scale;
+                    ctx.drawImage(img, frame.x + (frame.w - w) / 2, frame.y + (frame.h - h) / 2, w, h);
+                }
+
+                ctx.fillStyle = '#1f2330';
+                ctx.font = '600 40px ' + font;
+                ctx.fillText('Is YOUR handstand secretly a banana?', size / 2, 950);
+                ctx.font = '800 52px ' + font;
+                ctx.fillText('fixmybanana.com', size / 2, 1020);
+
+                return new Promise(function(resolve) {
+                    canvas.toBlob(resolve, 'image/png');
+                });
+            });
+        }
+
+        function downloadBlob(blob) {
+            var url = URL.createObjectURL(blob);
+            var a = document.createElement('a');
+            a.href = url;
+            a.download = 'banana-score.png';
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            setTimeout(function() { URL.revokeObjectURL(url); }, 1000);
+        }
+
+        shareBtn.addEventListener('click', function() {
+            buildCard().then(function(blob) {
+                var file = blob && new File([blob], 'banana-score.png', { type: 'image/png' });
+                if (file && navigator.canShare && navigator.canShare({ files: [file] })) {
+                    navigator.share({ files: [file], text: shareText }).catch(function() {});
+                } else if (navigator.share) {
+                    navigator.share({ text: shareText, url: siteUrl }).catch(function() {});
+                } else if (blob) {
+                    downloadBlob(blob);
+                    if (navigator.clipboard) navigator.clipboard.writeText(shareText).catch(function() {});
+                    alert('Score card downloaded — share text copied to your clipboard!');
+                }
+            });
+        });
+
+        downloadBtn.addEventListener('click', function() {
+            buildCard().then(function(blob) { if (blob) downloadBlob(blob); });
+        });
     })();
 </script>
 {% endblock %}


### PR DESCRIPTION
## What's in here

**Creator attribution** — footer on every page (home, result, 429): "Built by Shirley He" linking to [whirleyworld.com](https://www.whirleyworld.com), LinkedIn, Instagram, GitHub.

**Privacy note** — one line on the homepage under the upload area: photos go to OpenAI for analysis and are auto-deleted within 24 hours. Backed by a new `purge_old_uploads()` in `app.py` that deletes uploads older than 24h on each new upload, so the promise is actually true (previously files sat on disk until a redeploy).

**Shareable banana score card** — the viral loop. Result page (good/bad verdicts only) gets a share section that canvas-renders a 1080×1080 PNG: verdict, banana score (100%/0%), the user's photo in a white frame, and fixmybanana.com as the hook. Mobile gets the native share sheet with the image attached (Web Share API); desktop falls back to download + share text copied to clipboard.

**README overhaul** — live link up top, how-it-works, stack, run-locally, privacy section, and a commented-out `static/demo.gif` slot with recording instructions.

**CLAUDE.md** — codifies the new deploy-safety workflow: main auto-deploys via Railway, so behavior changes go through branch + PR (this one is the first).

## Testing

Smoke-tested in a local venv: app imports, `GET /` returns 200 with footer + privacy note, all four `result.html` variants render (share section present only for good/bad), 429 page renders, and the purge deletes a 25h-old file while keeping a fresh one.

Not covered: the canvas/share JS runs client-side only — worth one manual click-through on the Railway deploy (or a PR preview env) before/after merge, on both desktop and a phone.

## Reminder

Merging deploys to www.fixmybanana.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)